### PR TITLE
Fix QEmuDriveOption to append "readonly" field with a comma separator

### DIFF
--- a/qemu-exec/src/main/java/org/anarres/qemu/exec/QEmuDriveOption.java
+++ b/qemu-exec/src/main/java/org/anarres/qemu/exec/QEmuDriveOption.java
@@ -217,8 +217,11 @@ public class QEmuDriveOption extends AbstractQEmuOption {
         appendTo(buf, "discard", discard);
         appendTo(buf, "werror", werror);
         appendTo(buf, "rerror", rerror);
-        if (readonly)
+        if (readonly) {
+            if (buf.length() > 0)
+                buf.append(",");
             buf.append("readonly");
+        }
         appendTo(buf, "copy-on-read", copyOnRead);
 
         add(line, "-drive", buf.toString());


### PR DESCRIPTION
Minor fix for QEmuDriveOption. If `readonly` is set to true, the string "readonly" is appended to the command-line without a comma separator. This change fixes that.
